### PR TITLE
Adding documentation in Readme and an advance example using SoftwareSerial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,41 @@ If desired timestamps can be prefixed to the debug message. Timestamp output can
 
 # How-To-Use Advanced
 Normally all debug output is redirected to the primary serial output of each board (`Serial`). In case you want to redirect the output to another output stream you can make use of `setDebugOutputStream(&Serial2)`.
+
+# Documentation
+### 1. `Debug` :   
+Arduino_DebugUtils Object that will be used for calling member functions.  
+
+### 2. Debug.setDebugLevel(int const debug_level) :
+Parameter debug_level in order of lowest to highest priority are : DBG_NONE, DBG_ERROR, DBG_WARNING, DBG_INFO (default), DBG_DEBUG, and DBG_VERBOSE.  
+Return type: void.  
+Example:
+```
+Debug.setDebugLevel(DBG_VERBOSE);
+```
+
+### 2. Debug.setDebugOutputStream(Stream * stream) : 
+By default, Output Stream is Serial. In advanced cases other objects could be other serial ports (if available), or can be a Software Serial object.
+Example:
+```
+SoftwareSerial mySerial(10, 11); // RX, TX
+...
+Debug.setDebugOutputStream(&mySerial);
+```
+
+### 3. Debug.timestampOn() :  
+Calling this function will switches on the timestamp in Debug.print() function call;
+By default, printing timestamp is off, unless turned on using this function call.
+
+### 4. Debug.timestampOff() :  
+Calling this function will switches off the timestamp in Debug.print() function call;
+
+### 5. Debug.print(int const debug_level, const char * fmt, ...);
+This function assess the debug_level and prints the message if parameter `debug_level` in `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using setDebugLevel() function).
+Example:
+```
+Debug.setDebugLevel(DBG_VERBOSE);
+int i = 0;
+Debug.print(DBG_VERBOSE, "DBG_VERBOSE i = %d", i);
+
+```

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -1,0 +1,29 @@
+/*
+ * Advanced Debug can be helpful in embedded applications when 
+ * there are more that two microcontrollers connected serially
+ * or a wireless sensor like Xbee is connected to the serial port 
+ * that will send data wirelessly to other Xbee node.
+ * 
+ * In boards like Ardunino Nano, UNO, MEGA only one serial port is available,
+ * therefore additional Software Serial ports can be made usinf SoftwareSerial
+ */
+
+#include "Arduino_DebugUtils.h"
+#include <SoftwareSerial.h>
+
+SoftwareSerial mySerial(10, 11); // RX, TX
+
+void setup() {
+  mySerial.begin(9600);
+  Debug.setDebugOutputStream(&mySerial);
+  Debug.setDebugLevel(DBG_VERBOSE);
+  Debug.timestampOn();
+}
+
+int i = 0;
+
+void loop() {
+  Debug.print(DBG_VERBOSE, "i = %d", i);
+  i++;
+  delay(1000);
+}


### PR DESCRIPTION
Updates one are:
1. Updated the **readme** file with the **documentation** of the functions available and how to use them.
2. Added an **advance example** that uses **SoftwareSerial** object as an output stream for the microcontrollers that only have one Serial port and use SoftwareSerial to create more ports.
```
SoftwareSerial mySerial(10, 11); // RX, TX  
mySerial.begin(9600);  
Debug.setDebugOutputStream(&mySerial);
```