### PR TITLE
Adding advance example and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Debug.setDebugLevel(DBG_VERBOSE);
 ```
 ### 2. Debug.setDebugOutputStream(Stream * stream) :
 By default, Output Stream is Serial. In advanced cases other objects could be other serial ports (if available), or can be a Software Serial object.
+
 Example:
 ```
 SoftwareSerial mySerial(10, 11); // RX, TX

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ SoftwareSerial mySerial(10, 11); // RX, TX
 Debug.setDebugOutputStream(&mySerial);
 ```
 ### 3. Debug.timestampOn() :
-Calling this function will switches on the timestamp in `Debug.print()` function call;
+Calling this function switches on the timestamp in the `Debug.print()` function call;
 By default, printing timestamp is off, unless turned on using this function call.
 
 ### 4. Debug.timestampOff() :

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ By default, printing timestamp is off, unless turned on using this function call
 Calling this function switches off the timestamp in the `Debug.print()` function call;
 
 ### 5. Debug.print(int const debug_level, const char * fmt, ...);
-This function assess the debug_level and prints the message if parameter `debug_level` in `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using setDebugLevel() function).
+This function prints the message if parameter `debug_level` in the `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using `setDebugLevel()` function).
 Example:
 ```
 Debug.setDebugLevel(DBG_VERBOSE);

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Arduino_DebugUtils Object that will be used for calling member functions.
 
 ### 2. Debug.setDebugLevel(int const debug_level) :
 Parameter debug_level in order of lowest to highest priority are : `DBG_NONE`, `DBG_ERROR`, `DBG_WARNING`, `DBG_INFO` (default), `DBG_DEBUG`, and `DBG_VERBOSE`. 
+
 Return type: void.
+
 Example:
 ```
 Debug.setDebugLevel(DBG_VERBOSE);

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Calling this function switches on the timestamp in the `Debug.print()` function 
 By default, printing timestamp is off, unless turned on using this function call.
 
 ### 4. Debug.timestampOff() :
-Calling this function will switches off the timestamp in `Debug.print()` function call;
+Calling this function switches off the timestamp in the `Debug.print()` function call;
 
 ### 5. Debug.print(int const debug_level, const char * fmt, ...);
 This function assess the debug_level and prints the message if parameter `debug_level` in `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using setDebugLevel() function).

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ If desired timestamps can be prefixed to the debug message. Timestamp output can
 Normally all debug output is redirected to the primary serial output of each board (`Serial`). In case you want to redirect the output to another output stream you can make use of `setDebugOutputStream(&Serial2)`.
 
 # Documentation
-### 1. Debug :
+### Debug :
 Arduino_DebugUtils Object that will be used for calling member functions.
 
-### 2. Debug.setDebugLevel(int const debug_level) :
+### Debug.setDebugLevel(int const debug_level) :
 Parameter debug_level in order of lowest to highest priority are : `DBG_NONE`, `DBG_ERROR`, `DBG_WARNING`, `DBG_INFO` (default), `DBG_DEBUG`, and `DBG_VERBOSE`. 
 
 Return type: void.
@@ -41,23 +41,45 @@ Example:
 ```
 Debug.setDebugLevel(DBG_VERBOSE);
 ```
-### 2. Debug.setDebugOutputStream(Stream * stream) :
+### Debug.setDebugOutputStream(Stream * stream) :
 By default, Output Stream is Serial. In advanced cases other objects could be other serial ports (if available), or can be a Software Serial object.
+
+Return type: void.
 
 Example:
 ```
 SoftwareSerial mySerial(10, 11); // RX, TX
 Debug.setDebugOutputStream(&mySerial);
 ```
-### 3. Debug.timestampOn() :
+### Debug.timestampOn() :
 Calling this function switches on the timestamp in the `Debug.print()` function call;
 By default, printing timestamp is off, unless turned on using this function call.
 
-### 4. Debug.timestampOff() :
+Return type: void.
+
+Example:
+```
+Debug.timestampOn();
+Debug.print(DBG_VERBOSE, "i = %d", i); //Output looks like : [ 21007 ] i = 21 
+```
+
+### Debug.timestampOff() :
 Calling this function switches off the timestamp in the `Debug.print()` function call;
 
-### 5. Debug.print(int const debug_level, const char * fmt, ...);
+Return type: void.
+
+Example:
+```
+Debug.timestampOff();
+Debug.print(DBG_VERBOSE, "i = %d", i); //Output looks like : i = 21 
+```
+
+
+### Debug.print(int const debug_level, const char * fmt, ...);
 This function prints the message if parameter `debug_level` in the `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using `setDebugLevel()` function).
+
+Return type: void.
+
 Example:
 ```
 Debug.setDebugLevel(DBG_VERBOSE);

--- a/README.md
+++ b/README.md
@@ -27,3 +27,41 @@ If desired timestamps can be prefixed to the debug message. Timestamp output can
 
 # How-To-Use Advanced
 Normally all debug output is redirected to the primary serial output of each board (`Serial`). In case you want to redirect the output to another output stream you can make use of `setDebugOutputStream(&Serial2)`.
+
+# Documentation
+### 1. Debug :   
+Arduino_DebugUtils Object that will be used for calling member functions.  
+
+### 2. Debug.setDebugLevel(int const debug_level) :
+Parameter debug_level in order of lowest to highest priority are : `DBG_NONE`, `DBG_ERROR`, `DBG_WARNING`, `DBG_INFO` (default), `DBG_DEBUG`, and `DBG_VERBOSE`.  
+Return type: void.  
+Example:
+```
+Debug.setDebugLevel(DBG_VERBOSE);
+```
+
+### 2. Debug.setDebugOutputStream(Stream * stream) : 
+By default, Output Stream is Serial. In advanced cases other objects could be other serial ports (if available), or can be a Software Serial object.
+Example:
+```
+SoftwareSerial mySerial(10, 11); // RX, TX
+...
+Debug.setDebugOutputStream(&mySerial);
+```
+
+### 3. Debug.timestampOn() :  
+Calling this function will switches on the timestamp in `Debug.print()` function call;
+By default, printing timestamp is off, unless turned on using this function call.
+
+### 4. Debug.timestampOff() :  
+Calling this function will switches off the timestamp in `Debug.print()` function call;
+
+### 5. Debug.print(int const debug_level, const char * fmt, ...);
+This function assess the debug_level and prints the message if parameter `debug_level` in `Debug.print(debug_level, ...)` function call belongs to the range: DBG_ERROR <= debug_level <= (<DBG_LEVEL> that has been set using setDebugLevel() function).
+Example:
+```
+Debug.setDebugLevel(DBG_VERBOSE);
+int i = 0;
+Debug.print(DBG_VERBOSE, "DBG_VERBOSE i = %d", i);
+
+```

--- a/README.md
+++ b/README.md
@@ -29,31 +29,28 @@ If desired timestamps can be prefixed to the debug message. Timestamp output can
 Normally all debug output is redirected to the primary serial output of each board (`Serial`). In case you want to redirect the output to another output stream you can make use of `setDebugOutputStream(&Serial2)`.
 
 # Documentation
-### 1. Debug :   
-Arduino_DebugUtils Object that will be used for calling member functions.  
+### 1. Debug :
+Arduino_DebugUtils Object that will be used for calling member functions.
 
 ### 2. Debug.setDebugLevel(int const debug_level) :
-Parameter debug_level in order of lowest to highest priority are : `DBG_NONE`, `DBG_ERROR`, `DBG_WARNING`, `DBG_INFO` (default), `DBG_DEBUG`, and `DBG_VERBOSE`.  
-Return type: void.  
+Parameter debug_level in order of lowest to highest priority are : `DBG_NONE`, `DBG_ERROR`, `DBG_WARNING`, `DBG_INFO` (default), `DBG_DEBUG`, and `DBG_VERBOSE`. 
+Return type: void.
 Example:
 ```
 Debug.setDebugLevel(DBG_VERBOSE);
 ```
-
-### 2. Debug.setDebugOutputStream(Stream * stream) : 
+### 2. Debug.setDebugOutputStream(Stream * stream) :
 By default, Output Stream is Serial. In advanced cases other objects could be other serial ports (if available), or can be a Software Serial object.
 Example:
 ```
 SoftwareSerial mySerial(10, 11); // RX, TX
-...
 Debug.setDebugOutputStream(&mySerial);
 ```
-
-### 3. Debug.timestampOn() :  
+### 3. Debug.timestampOn() :
 Calling this function will switches on the timestamp in `Debug.print()` function call;
 By default, printing timestamp is off, unless turned on using this function call.
 
-### 4. Debug.timestampOff() :  
+### 4. Debug.timestampOff() :
 Calling this function will switches off the timestamp in `Debug.print()` function call;
 
 ### 5. Debug.print(int const debug_level, const char * fmt, ...);
@@ -63,5 +60,4 @@ Example:
 Debug.setDebugLevel(DBG_VERBOSE);
 int i = 0;
 Debug.print(DBG_VERBOSE, "DBG_VERBOSE i = %d", i);
-
 ```

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -1,8 +1,8 @@
 /*
  * Advanced Debug can be helpful in embedded applications when 
  * there are more that two microcontrollers connected serially
- * or a wireless sensor like Xbee is connected to the serial port 
- * that will send data wirelessly to other Xbee node.
+ * or a wireless sensor like XBee is connected to the serial port 
+ * that will send data wirelessly to other XBee node.
  * 
  * In boards like Arduino Nano, UNO, MEGA only one serial port is available,
  * therefore additional Software Serial ports can be made using SoftwareSerial

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -1,12 +1,12 @@
 /*
- * Advanced Debug can be helpful in embedded applications when 
- * there are more that two microcontrollers connected serially
- * or a wireless sensor like XBee is connected to the serial port 
- * that will send data wirelessly to other XBee node.
- * 
- * In boards like Arduino Nano, UNO, MEGA only one serial port is available,
- * therefore additional Software Serial ports can be made using SoftwareSerial
- */
+   Advanced Debug can be helpful in embedded applications when
+   there are more that two microcontrollers connected serially
+   or a wireless sensor like XBee is connected to the serial port
+   that will send data wirelessly to other XBee node.
+
+   In boards like Arduino Nano, UNO, MEGA only one serial port is available,
+   therefore additional Software Serial ports can be made using SoftwareSerial
+*/
 
 #include "Arduino_DebugUtils.h"
 #include <SoftwareSerial.h>

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -4,7 +4,7 @@
  * or a wireless sensor like Xbee is connected to the serial port 
  * that will send data wirelessly to other Xbee node.
  * 
- * In boards like Ardunino Nano, UNO, MEGA only one serial port is available,
+ * In boards like Arduino Nano, UNO, MEGA only one serial port is available,
  * therefore additional Software Serial ports can be made using SoftwareSerial
  */
 

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -1,0 +1,29 @@
+/*
+ * Advanced Debug can be helpful in embedded applications when 
+ * there are more that two microcontrollers connected serially
+ * or a wireless sensor like Xbee is connected to the serial port 
+ * that will send data wirelessly to other Xbee node.
+ * 
+ * In boards like Ardunino Nano, UNO, MEGA only one serial port is available,
+ * therefore additional Software Serial ports can be made usinf SoftwareSerial
+ */
+
+#include "Arduino_DebugUtils.h"
+#include <SoftwareSerial.h>
+
+SoftwareSerial mySerial(10, 11); // RX, TX
+
+void setup() {
+  mySerial.begin(9600);
+  Debug.setDebugOutputStream(&mySerial);
+  Debug.setDebugLevel(DBG_VERBOSE);
+  Debug.timestampOn();
+}
+
+int i = 0;
+
+void loop() {
+  Debug.print(DBG_VERBOSE, "i = %d", i);
+  i++;
+  delay(1000);
+}

--- a/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
+++ b/examples/Arduino_Debug_Advance/Arduino_Debug_Advance.ino
@@ -5,7 +5,7 @@
  * that will send data wirelessly to other Xbee node.
  * 
  * In boards like Ardunino Nano, UNO, MEGA only one serial port is available,
- * therefore additional Software Serial ports can be made usinf SoftwareSerial
+ * therefore additional Software Serial ports can be made using SoftwareSerial
  */
 
 #include "Arduino_DebugUtils.h"


### PR DESCRIPTION
Adding an advance example that can make use of software serial as old Arduino boards only have one Serial and thus using your library with **SoftwareSerial** output Stream will give lots of **flexibility.**  

Adding **documentation** as it will help the users to know how to use this library and what all ways are there.   
