### PR TITLE
Fix: va_start(va_list ap, paramN) needs to be parametrized with the latest named parameter in the parameter list.

### DIFF
--- a/src/Arduino_DebugUtils.cpp
+++ b/src/Arduino_DebugUtils.cpp
@@ -83,7 +83,7 @@ void Arduino_DebugUtils::print(int const debug_level, const __FlashStringHelper 
   String fmt_str(fmt);
 
   va_list args;
-  va_start(args, fmt_str.c_str());
+  va_start(args, fmt);
   vPrint(fmt_str.c_str(), args);
   va_end(args);
 }


### PR DESCRIPTION
This fixes #12.

https://www.cplusplus.com/reference/cstdarg/va_start/