### PR TITLE
Remove hardcoded line length limit

### DIFF
--- a/src/Arduino_DebugUtils.cpp
+++ b/src/Arduino_DebugUtils.cpp
@@ -108,7 +108,7 @@ void Arduino_DebugUtils::vPrint(char const * fmt, va_list args) {
   // in the rare case where VLA is not allowed by compiler, fall back on heap-allocated memory
   char * msg_buf = new char[msg_buf_size];
 #else
-  char msg_buf[msg_buf_size] = {0};
+  char msg_buf[msg_buf_size];
 #endif
 
   vsnprintf(msg_buf, msg_buf_size, fmt, args);


### PR DESCRIPTION
The length of a single print statement seems arbitrarily limited to 119 characters (120 byte buffer). This could create unforeseen issues where long print statements are being truncated unexpectedly, especially since this isn't documented anywhere.

This PR removes the line length restriction, by pre-calculating the required buffer length. Then the buffer is created, preferably using a variable-length array, or heap allocation if VLAs aren't supported.

This change would make the library more intuitive, since print statements aren't being truncated unexpectedly.