### PR TITLE
Add public print method that takes va_list instead of a variable number of arguments

### DIFF
--- a/src/Arduino_DebugUtils.cpp
+++ b/src/Arduino_DebugUtils.cpp
@@ -91,22 +91,23 @@ void Arduino_DebugUtils::timestampOff() {
 
 void Arduino_DebugUtils::print(int const debug_level, const char * fmt, ...)
 {
-  if (!shouldPrint(debug_level))
-    return;
-
-  if (_print_debug_label)
-    printDebugLabel(debug_level);
-
-  if (_timestamp_on)
-    printTimestamp();
-
   va_list args;
   va_start(args, fmt);
-  vPrint(fmt, args);
+  print(debug_level, fmt, args);
   va_end(args);
 }
 
 void Arduino_DebugUtils::print(int const debug_level, const __FlashStringHelper * fmt, ...)
+{
+  String fmt_str(fmt);
+
+  va_list args;
+  va_start(args, fmt);
+  print(debug_level, fmt_str.c_str(), args);
+  va_end(args);
+}
+
+void Arduino_DebugUtils::print(int const debug_level, const char * fmt, va_list args)
 {
   if (!shouldPrint(debug_level))
     return;
@@ -117,12 +118,7 @@ void Arduino_DebugUtils::print(int const debug_level, const __FlashStringHelper 
   if (_timestamp_on)
     printTimestamp();
 
-  String fmt_str(fmt);
-
-  va_list args;
-  va_start(args, fmt);
-  vPrint(fmt_str.c_str(), args);
-  va_end(args);
+  vPrint(fmt, args);
 }
 
 /******************************************************************************

--- a/src/Arduino_DebugUtils.h
+++ b/src/Arduino_DebugUtils.h
@@ -69,7 +69,7 @@ class Arduino_DebugUtils {
 
     void print(int const debug_level, const char * fmt, ...);
     void print(int const debug_level, const __FlashStringHelper * fmt, ...);
-
+    void print(int const debug_level, const char * fmt, va_list args);
 
   private:
 


### PR DESCRIPTION
I was tryng to improve [SE05X](https://github.com/arduino/ArduinoCore-renesas/tree/main/libraries/SE05X) library and get rid of [this](https://github.com/arduino/ArduinoCore-renesas/blob/5020fd42299dd703ebd096fdee8df743ccc7a66d/libraries/SE05X/src/lib/platform/arduino/sm_port.cpp#L23) buffer used only for debugging purpose. To this i wanted to reuse Arduino_DebugUtils library.

SE05X NXP internal library already has builtin debug macros and is written in C so i cannot directly call `Arduino_DebugUtils.print` function as macro substitution, but i need to create a wrapper CPP function with varargs that calls the `Arduino_DebugUtils.print` method.

What i've found out is that [is not possible to call a function which takes a variable number of arguments and passes them to some other function (which takes a variable number of arguments)](https://c-faq.com/varargs/handoff.html) so the proposal to add a new method that takes `va_list`

Probably another option is to use a [variadic function template](https://en.cppreference.com/w/cpp/language/parameter_pack#:%7E:text=A-,variadic%20function%20template,-can%20be%20called) or using [__builtin_apply](https://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Constructing-Calls.html) but i did not investigate them and i think the proposed option is more straightforward.