### PR TITLE
Standardize license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,17 +1,3 @@
-This file includes licensing information for Arduino_DebugUtils.
-
-Copyright (c) 2018 ARDUINO SA (www.arduino.cc)
-
-The software is released under the GNU General Public License, which covers the main body
-of the Arduino_DebugUtils code. The terms of this license can be found at:
-https://www.gnu.org/licenses/gpl-3.0.en.html
-
-You can be released from the requirements of the above licenses by purchasing
-a commercial license. Buying such a license is mandatory if you want to modify or
-otherwise use the software for commercial activities involving the Arduino
-software without disclosing the source code of your own applications. To purchase
-a commercial license, send an email to license@arduino.cc
-
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
@@ -645,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Arduino_DebugUtils encapsulates functionality useful for debugging code via printf statements.
-    Copyright (C) Arduino SA, 2019, Author: Alexander Entinger
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -666,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    Arduino_DebugUtils Copyright (C) 2019, Arduino SA
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/README.md
+++ b/README.md
@@ -111,3 +111,9 @@ Debug.setDebugLevel(DBG_VERBOSE);
 int i = 0;
 DEBUG_VERBOSE("DBG_VERBOSE i = %d", i);
 ```
+
+# License
+
+Arduino_DebugUtils is licensed under the GNU General Public License v3.0.
+
+You can be released from the requirements of the above license by purchasing a commercial license. Buying such a license is mandatory if you want to modify or otherwise use the software for commercial activities involving the Arduino software without disclosing the source code of your own applications. To purchase a commercial license, send an email to license@arduino.cc


### PR DESCRIPTION
Standardization in license documentation is important because, in addition to making it easy for humans to find this vital information, it allows machines to automate the process of license type determination, which is useful both for discovering suitable open source projects as well as checking open source license compliance.

The open source license of this project is already stored in a [standardized location](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#determining-the-location-of-your-license) in a dedicated license file. However, even though the project is licensed under a standardized open source license, additional text was added to the license file which offers the option to purchase an [exception for proprietary use of the project](https://www.gnu.org/philosophy/selling-exceptions.html). Even though this offer does not have any legal effect on the open source license, the presence of that text made it so that the open license type could not be identified with 100% confidence by machines (e.g., the [**Licensee** Gem](https://github.com/licensee/licensee) which is [used by the GitHub website](https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license)), which meant identification could only be made by a human carefully evaluating the license text.

Since there is no need to place the exception offer in the license file, it can be moved to the readme, with the license file containing only [the verbatim standardized open source license text](https://choosealicense.com/appendix/). The result is that the project's open source license type can now be automatically identified, without making any change to the licensing.